### PR TITLE
feat(ops): Randomize Orientation of Crystal Waters During Hydrogenation

### DIFF
--- a/src/ops/hydro.rs
+++ b/src/ops/hydro.rs
@@ -526,11 +526,9 @@ fn reconstruct_geometry(
 
     let (mut rot, mut trans) = calculate_transform(&residue_pts, &template_pts).ok_or(())?;
 
-    if let Some(override_rot) = rotation_override {
-        if anchor_names.len() == 1 {
-            rot = override_rot.into_inner();
-            trans = residue_pts[0].coords - rot * template_pts[0].coords;
-        }
+    if let (Some(override_rot), 1) = (rotation_override, anchor_names.len()) {
+        rot = override_rot.into_inner();
+        trans = residue_pts[0].coords - rot * template_pts[0].coords;
     }
 
     Ok(rot * target_tmpl_pos + trans)


### PR DESCRIPTION
### Summary:

Introduces random orientation for crystal waters (`HOH`) during the hydrogenation process. Previously, the orientation of reconstructed water hydrogens was deterministic, leading to an artificially uniform solvent structure. By applying a random rotation to each water molecule that is being re-hydrogenated, we now generate a more diverse and physically plausible solvent environment.

### Changes:

- **Enhanced Hydrogenation Logic for Water:**
  - In `ops::hydro::construct_hydrogens_for_residue`, added logic to specifically detect when the residue being processed is a water molecule (`StandardResidue::HOH`).
  - For each water molecule, a new random `Rotation3` matrix is now generated.

- **Updated Geometry Reconstruction:**
  - The `reconstruct_geometry` function was updated to accept an optional `rotation_override: Option<Rotation3<f64>>`.
  - When a `rotation_override` is provided and the system is geometrically under-constrained (e.g., a water molecule with only one "O" anchor atom), the function now uses the provided random rotation.
  - This avoids a deterministic orientation and correctly positions the hydrogens by recalculating the translation based on the new random rotation.