### PR TITLE
fix(web): Prevent File Card Expansion When Selecting Files

### DIFF
--- a/web/src/features/files/file-card.tsx
+++ b/web/src/features/files/file-card.tsx
@@ -148,11 +148,12 @@ export function FileCard({ file }: FileCardProps) {
           onClick={() => toggleExpanded(file.id)}
         >
           {/* Selection checkbox */}
-          <Checkbox
-            checked={isSelected}
-            onChange={() => toggleSelection(file.id)}
-            onClick={(e) => e.stopPropagation()}
-          />
+          <div onClick={(e) => e.stopPropagation()}>
+            <Checkbox
+              checked={isSelected}
+              onChange={() => toggleSelection(file.id)}
+            />
+          </div>
 
           {/* File info - responsive layout */}
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
### Summary:

Fixed a UI interaction issue in the `FileCard` component where clicking the selection checkbox would incorrectly trigger the card's expansion logic. This was caused by the click event bubbling up to the parent container. The fix involves wrapping the checkbox in a dedicated container that explicitly stops event propagation, ensuring that selection and expansion actions remain independent.

### Changes:

- **Updated `FileCard.tsx`:**
  - Wrapped the `Checkbox` component within a `div` element.
  - Moved the `e.stopPropagation()` logic to the `onClick` handler of this wrapper `div`.
  - This ensures that clicks on the checkbox (or its label area) do not bubble up to the card's main click handler, preventing unwanted expansion/collapse toggling.