### PR TITLE
fix(ops): Refine Terminal Geometry and Decouple Local Construction from Global Alignment

### DIFF
--- a/crates/bio-forge/src/ops/hydro.rs
+++ b/crates/bio-forge/src/ops/hydro.rs
@@ -26,6 +26,14 @@ const N_TERM_PKA: f64 = 8.0;
 const C_TERM_PKA: f64 = 3.1;
 /// Henderson–Hasselbalch breakpoint for the second dissociation of terminal phosphate.
 const PHOSPHATE_PKA2: f64 = 6.5;
+/// Standard sp³ tetrahedral bond angle (degrees).
+const SP3_ANGLE: f64 = 109.5;
+/// Standard N-H bond length (Å).
+const NH_BOND_LENGTH: f64 = 1.01;
+/// Standard O-H bond length (Å).
+const OH_BOND_LENGTH: f64 = 0.96;
+/// Carboxylic acid O-H bond length (Å).
+const COOH_BOND_LENGTH: f64 = 0.97;
 
 /// Parameters controlling hydrogen addition behavior.
 ///
@@ -625,46 +633,22 @@ fn construct_n_term_hydrogens(residue: &mut Residue, protonated: bool) -> Result
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "CA"))?
         .pos;
 
-    let v_ca_n = (n_pos - ca_pos).normalize();
-    let bond_len = 1.0;
-    let angle = 109.5_f64.to_radians();
-    let sin_a = angle.sin();
-    let cos_a = angle.cos();
+    let (x, y, z) = build_sp3_frame(n_pos, ca_pos, None);
 
-    let up = if v_ca_n.x.abs() < 0.9 {
-        Vector3::x()
-    } else {
-        Vector3::y()
-    };
-    let v_perp = v_ca_n.cross(&up).normalize();
-    let base_dir = v_ca_n.scale(cos_a) + v_perp.scale(sin_a);
+    let theta = SP3_ANGLE.to_radians();
+    let sin_theta = theta.sin();
+    let cos_theta = theta.cos();
 
     let phases = [0.0_f64, 120.0, 240.0];
-    let mut candidates: Vec<Vector3<f64>> = phases
-        .iter()
-        .map(|deg| {
-            let rot_axis = Rotation3::from_axis_angle(
-                &nalgebra::Unit::new_normalize(v_ca_n),
-                deg.to_radians(),
-            );
-            rot_axis * base_dir
-        })
-        .collect();
-
-    candidates.sort_by(|a, b| {
-        a.dot(&v_ca_n)
-            .partial_cmp(&b.dot(&v_ca_n))
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-
     let target_count = if protonated { 3 } else { 2 };
     let names = ["H1", "H2", "H3"];
-    for (idx, dir) in candidates.into_iter().take(target_count).enumerate() {
-        residue.add_atom(Atom::new(
-            names[idx],
-            Element::H,
-            n_pos + dir.scale(bond_len),
-        ));
+
+    for (idx, phase) in phases.iter().take(target_count).enumerate() {
+        let phi = phase.to_radians();
+        let h_local = Vector3::new(sin_theta * phi.cos(), sin_theta * phi.sin(), -cos_theta);
+        let h_global = x * h_local.x + y * h_local.y + z * h_local.z;
+        let h_pos = n_pos + h_global * NH_BOND_LENGTH;
+        residue.add_atom(Atom::new(names[idx], Element::H, h_pos));
     }
 
     Ok(())
@@ -705,16 +689,28 @@ fn construct_c_term_hydrogen(residue: &mut Residue, protonated: bool) -> Result<
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "OXT"))?
         .pos;
 
-    let direction = oxt_pos - c_pos;
-    if direction.norm_squared() < 1e-6 {
+    let c_oxt_dist = (oxt_pos - c_pos).norm();
+    if c_oxt_dist < 1e-6 {
         return Err(Error::incomplete_for_hydro(
             &*residue.name,
             residue.id,
             "OXT",
         ));
     }
-    let dir = direction.normalize();
-    let h_pos = oxt_pos + dir.scale(0.97);
+
+    let reference_pos = residue
+        .atom("CA")
+        .or_else(|| residue.atom("O"))
+        .map(|a| a.pos);
+
+    let h_pos = place_hydroxyl_hydrogen(
+        oxt_pos,
+        c_pos,
+        reference_pos,
+        COOH_BOND_LENGTH,
+        SP3_ANGLE,
+        60.0,
+    );
 
     residue.add_atom(Atom::new("HOXT", Element::H, h_pos));
     Ok(())
@@ -738,27 +734,28 @@ fn construct_3_prime_hydrogen(residue: &mut Residue) -> Result<(), Error> {
         return Ok(());
     }
 
-    let o3 = residue
+    let o3_pos = residue
         .atom("O3'")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "O3'"))?
         .pos;
-    let c3 = residue
+    let c3_pos = residue
         .atom("C3'")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "C3'"))?
         .pos;
-    let c4 = residue
+
+    let reference_pos = residue
         .atom("C4'")
         .or_else(|| residue.atom("C2'"))
-        .map(|a| a.pos)
-        .unwrap_or_else(|| c3 + Vector3::x());
+        .map(|a| a.pos);
 
-    let v_c3_o3 = (o3 - c3).normalize();
-
-    let v_c4_c3 = (c3 - c4).normalize();
-    let normal = v_c3_o3.cross(&v_c4_c3).normalize();
-
-    let h_dir = (v_c3_o3 + normal).normalize();
-    let h_pos = o3 + h_dir.scale(0.96);
+    let h_pos = place_hydroxyl_hydrogen(
+        o3_pos,
+        c3_pos,
+        reference_pos,
+        OH_BOND_LENGTH,
+        SP3_ANGLE,
+        180.0,
+    );
 
     residue.add_atom(Atom::new("HO3'", Element::H, h_pos));
     Ok(())
@@ -782,25 +779,25 @@ fn construct_5_prime_hydrogen(residue: &mut Residue) -> Result<(), Error> {
         return Ok(());
     }
 
-    let o5 = residue
+    let o5_pos = residue
         .atom("O5'")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "O5'"))?
         .pos;
-    let c5 = residue
+    let c5_pos = residue
         .atom("C5'")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "C5'"))?
         .pos;
 
-    let v_c5_o5 = (o5 - c5).normalize();
-    let aux = if v_c5_o5.z.abs() < 0.9 {
-        Vector3::z()
-    } else {
-        Vector3::x()
-    };
-    let perp = v_c5_o5.cross(&aux).normalize();
+    let reference_pos = residue.atom("C4'").map(|a| a.pos);
 
-    let h_dir = (v_c5_o5 + perp).normalize();
-    let h_pos = o5 + h_dir.scale(0.96);
+    let h_pos = place_hydroxyl_hydrogen(
+        o5_pos,
+        c5_pos,
+        reference_pos,
+        OH_BOND_LENGTH,
+        SP3_ANGLE,
+        180.0,
+    );
 
     residue.add_atom(Atom::new("HO5'", Element::H, h_pos));
     Ok(())
@@ -809,8 +806,8 @@ fn construct_5_prime_hydrogen(residue: &mut Residue) -> Result<(), Error> {
 /// Adds hydrogens to 5'-terminal phosphate groups based on pH.
 ///
 /// At physiological pH (≥6.5), the terminal phosphate carries two negative charges and
-/// requires no protons. Below this threshold, one proton is added to OP3. The function
-/// respects existing hydrogens when `remove_existing_h` is disabled.
+/// requires no protons. Below this threshold, one proton is added to OP3 with proper
+/// sp³ tetrahedral geometry: P-OP3-HOP3 ≈ 109.5°.
 ///
 /// # Arguments
 ///
@@ -840,20 +837,110 @@ fn construct_5_prime_phosphate_hydrogens(
         return Ok(());
     }
 
-    let op3 = residue
+    let op3_pos = residue
         .atom("OP3")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "OP3"))?
         .pos;
-    let p = residue
+    let p_pos = residue
         .atom("P")
         .ok_or_else(|| Error::incomplete_for_hydro(&*residue.name, residue.id, "P"))?
         .pos;
 
-    let direction = (op3 - p).normalize();
-    let h_pos = op3 + direction * 0.96;
+    let reference_pos = residue
+        .atom("OP1")
+        .or_else(|| residue.atom("OP2"))
+        .map(|a| a.pos);
+
+    let h_pos = place_hydroxyl_hydrogen(
+        op3_pos,
+        p_pos,
+        reference_pos,
+        OH_BOND_LENGTH,
+        SP3_ANGLE,
+        180.0,
+    );
 
     residue.add_atom(Atom::new("HOP3", Element::H, h_pos));
     Ok(())
+}
+
+/// Builds an sp³ local coordinate frame centered at `center` with primary axis along
+/// `center - attached`.
+///
+/// # Arguments
+///
+/// * `center` - Center atom position (e.g., oxygen).
+/// * `attached` - Position of the atom bonded to center (e.g., carbon).
+/// * `reference` - Optional third atom for defining the xy-plane orientation.
+///
+/// # Returns
+///
+/// A tuple of orthonormal vectors `(x, y, z)` where `z` points from attached toward center.
+fn build_sp3_frame(
+    center: Point,
+    attached: Point,
+    reference: Option<Point>,
+) -> (Vector3<f64>, Vector3<f64>, Vector3<f64>) {
+    let z = (center - attached).normalize();
+
+    let ref_vec = reference
+        .map(|r| (r - attached).normalize())
+        .unwrap_or_else(|| {
+            if z.x.abs() < z.y.abs() && z.x.abs() < z.z.abs() {
+                Vector3::x()
+            } else if z.y.abs() < z.z.abs() {
+                Vector3::y()
+            } else {
+                Vector3::z()
+            }
+        });
+
+    let x = (ref_vec - z * z.dot(&ref_vec)).normalize();
+
+    let y = z.cross(&x);
+
+    (x, y, z)
+}
+
+/// Places a hydroxyl hydrogen using sp³ tetrahedral geometry.
+///
+/// The hydrogen is placed at `bond_length` from `o_pos`, with the angle
+/// `attached-O-H` equal to `bond_angle`, and rotated by `dihedral_offset`
+/// around the `attached-O` axis.
+///
+/// # Arguments
+///
+/// * `o_pos` - Position of the oxygen atom.
+/// * `attached_pos` - Position of the atom bonded to oxygen.
+/// * `reference_pos` - Optional reference for determining dihedral orientation.
+/// * `bond_length` - O-H bond length (typically 0.96 Å).
+/// * `bond_angle` - The angle attached-O-H in degrees (typically 109.5°).
+/// * `dihedral_offset` - Rotation around the attached-O axis in degrees.
+///
+/// # Returns
+///
+/// The calculated hydrogen position.
+fn place_hydroxyl_hydrogen(
+    o_pos: Point,
+    attached_pos: Point,
+    reference_pos: Option<Point>,
+    bond_length: f64,
+    bond_angle: f64,
+    dihedral_offset: f64,
+) -> Point {
+    let (x, y, z) = build_sp3_frame(o_pos, attached_pos, reference_pos);
+
+    let theta = bond_angle.to_radians();
+    let phi = dihedral_offset.to_radians();
+
+    let sin_theta = theta.sin();
+    let cos_theta = theta.cos();
+
+    let h_local = Vector3::new(sin_theta * phi.cos(), sin_theta * phi.sin(), -cos_theta);
+
+    let h_global = x * h_local.x + y * h_local.y + z * h_local.z;
+
+    o_pos + h_global * bond_length
 }
 
 /// Computes the optimal rigid transform mapping template anchor points to residue atoms.

--- a/crates/bio-forge/src/ops/repair.rs
+++ b/crates/bio-forge/src/ops/repair.rs
@@ -24,6 +24,12 @@ const CARBOXYL_OCO_ANGLE_DEG: f64 = 126.0;
 /// Standard P-O bond length in phosphate groups (Å).
 const PHOSPHATE_PO_BOND_LENGTH: f64 = 1.48;
 
+/// Alignment pair mapping residue position to template position.
+type AlignmentPairs = Vec<(Point, Point)>;
+
+/// Missing atom data: (name, element, template_position).
+type MissingAtoms = Vec<(String, Element, Point)>;
+
 /// Repairs every standard residue in a structure by invoking the internal repair logic.
 ///
 /// Non-standard residues (heterogens, ions, solvent) are left untouched to avoid tampering
@@ -203,7 +209,7 @@ fn collect_alignment_data(
     residue: &Residue,
     template: db::TemplateView,
     status: &TerminalStatus,
-) -> (Vec<(Point, Point)>, Vec<(String, Element, Point)>) {
+) -> (AlignmentPairs, MissingAtoms) {
     let mut align_pairs = Vec::new();
     let mut missing_atoms = Vec::new();
 

--- a/crates/bio-forge/src/ops/repair.rs
+++ b/crates/bio-forge/src/ops/repair.rs
@@ -307,12 +307,12 @@ fn calculate_transform(pairs: &[(Point, Point)]) -> Result<Transform, Error> {
 
     let svd = cov.svd(true, true);
 
-    let u = svd
-        .u
-        .ok_or_else(|| Error::alignment_failed("N/A", 0, "SVD U matrix computation failed"))?;
-    let v_t = svd
-        .v_t
-        .ok_or_else(|| Error::alignment_failed("N/A", 0, "SVD V_T matrix computation failed"))?;
+    let u = svd.u.ok_or_else(|| {
+        Error::alignment_failed("", 0, "SVD decomposition failed: U matrix unavailable")
+    })?;
+    let v_t = svd.v_t.ok_or_else(|| {
+        Error::alignment_failed("", 0, "SVD decomposition failed: V^T matrix unavailable")
+    })?;
 
     let mut rotation = u * v_t;
     if rotation.determinant() < 0.0 {

--- a/crates/bio-forge/src/ops/repair.rs
+++ b/crates/bio-forge/src/ops/repair.rs
@@ -327,7 +327,7 @@ fn calculate_transform(pairs: &[(Point, Point)]) -> Result<Transform, Error> {
     })
 }
 
-/// Synthesizes missing template atoms by applying the SVD transform.
+/// Synthesizes missing template atoms by applying the rigid transform.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
### Summary:

Addresses geometric artifacts observed in reconstructed terminal atoms (N-terminal hydrogens, C-terminal OXT, and nucleic acid termini). The previous implementation of `calculate_transform` was too simplistic for single/double atom alignments and relied on global SVD coupling which could distort local geometry. Additionally, terminal atom construction has been rewritten to use robust local coordinate frames based on standard bond lengths and angles, rather than rough vector approximations.

#### Cases:

##### N-terminal: Amino Group (NH3+)

![Image](https://github.com/user-attachments/assets/2a3369ca-72fb-4718-a8ec-0bac73d0d1f3)

##### C-terminal: Carboxylate Ion Group (COO-)

![Image](https://github.com/user-attachments/assets/309ab486-3ee5-421d-8863-4424e4003cac)

##### C-terminal: Carboxylate Group (COOH)

![Image](https://github.com/user-attachments/assets/922fbd7e-642f-4bf7-a080-3786d72bac59)

### Changes:

- **Enhanced `construct_n_term_hydrogens`:**
  - Now uses a local sp³ frame built from the N and CA atoms (and a reference vector) to place H1, H2, and H3.
  - Enforces a standard N-H bond length of 1.01 Å and tetrahedral angles (109.5°), replacing the previous approximate direction logic.
  - Supports staggered conformations (0°, 120°, 240°) for protonated amines.

- **Refined `construct_c_term_hydrogen`:**
  - Implemented `place_hydroxyl_hydrogen` helper to position the HOXT atom with precise geometry (0.97 Å bond length, 109.5° angle, and 60° torsion).
  - Uses the carboxyl plane (defined by C, O, and CA) to orient the hydrogen correctly relative to the OXT atom.

- **Improved Nucleic Acid Termini (`construct_3_prime_hydrogen`, `construct_5_prime_hydrogen`):**
  - Updated both functions to use `place_hydroxyl_hydrogen` for consistent O-H bond geometry.
  - Ensures 3'-OH and 5'-OH groups are placed with correct bond lengths and tetrahedral angles relative to the sugar ring.

- **Robust 5'-Phosphate Protonation (`construct_5_prime_phosphate_hydrogens`):**
  - Implemented correct sp³ geometry for the HOP3 proton on terminal phosphates.
  - Positions the hydrogen at 0.96 Å from OP3 with a 109.5° P-O-H angle, oriented 180° dihedral relative to the P-O bond vector.

- **Decoupled SVD Alignment:**
  - Refactored `calculate_transform` in `ops/repair.rs` to handle 1-point and 2-point alignments explicitly and correctly.
  - Single-point alignment now performs pure translation without inducing rotation.
  - Two-point alignment computes the minimal rotation required to align the vector without introducing arbitrary twists around that axis.
  - SVD is now reserved for cases with 3 or more points, ensuring robust least-squares fitting for bulk atoms.

- **Local Geometry Helpers:**
  - Added `build_sp3_frame` and `place_hydroxyl_hydrogen` utilities to `ops/hydro.rs`.
  - Added geometric constants (`SP3_ANGLE`, `NH_BOND_LENGTH`, etc.) to enforce physical realism.

- **Updated Tests:**
  - Added comprehensive geometric validation tests (`n_terminal_h_has_tetrahedral_geometry`, `c_terminal_hoxt_has_tetrahedral_geometry`, etc.) that check bond lengths and angles against expected physical values.