### PR TITLE
Added configurable salt concentration

### DIFF
--- a/crates/bio-forge-wasm/src/lib.rs
+++ b/crates/bio-forge-wasm/src/lib.rs
@@ -180,6 +180,8 @@ pub struct SolvateConfig {
     /// Target net charge after solvation. Default: `0`
     #[serde(default)]
     pub target_charge: i32,
+    #[serde(default)]
+    pub salt_concentration: Option<f64>,
     /// Random seed for reproducible placement.
     #[serde(default)]
     pub rng_seed: Option<u64>,
@@ -211,6 +213,7 @@ impl Default for SolvateConfig {
             cations: default_cations(),
             anions: default_anions(),
             target_charge: 0,
+            salt_concentration: None,
             rng_seed: None,
         }
     }
@@ -250,6 +253,7 @@ impl From<SolvateConfig> for CoreSolvateConfig {
             cations,
             anions,
             target_charge: cfg.target_charge,
+            salt_concentration: cfg.salt_concentration,
             rng_seed: cfg.rng_seed,
         }
     }

--- a/crates/bio-forge/src/bin/commands/solvate.rs
+++ b/crates/bio-forge/src/bin/commands/solvate.rs
@@ -31,6 +31,9 @@ pub struct SolvateArgs {
         conflicts_with = "neutralize"
     )]
     pub target_charge: Option<i32>,
+    /// Desired salt concentration (M)
+    #[arg(long = "salt-concentration", value_name = "CONCENTRATION")]
+    pub salt_concentration: Option<f64>,
     /// Random seed used for deterministic ion placement.
     #[arg(long, value_name = "INT")]
     pub seed: Option<u64>,
@@ -44,6 +47,7 @@ pub fn run(structure: &mut Structure, args: &SolvateArgs) -> Result<()> {
             water_spacing: args.spacing,
             cations: vec![parse_cation(&args.cation)?],
             anions: vec![parse_anion(&args.anion)?],
+            salt_concentration: args.salt_concentration,
             rng_seed: args.seed,
             ..SolvateConfig::default()
         };

--- a/crates/bio-forge/src/model/structure.rs
+++ b/crates/bio-forge/src/model/structure.rs
@@ -513,6 +513,26 @@ impl Structure {
             .collect();
         Grid::new(items, cell_size)
     }
+
+    pub fn box_volume(&self) -> Option<f64> {
+        match self.box_vectors {
+            Some(box_vectors) => Some(box_volume(box_vectors)),
+            None => None,
+        }
+    }
+}
+
+fn box_volume(box_vectors: [[f64; 3]; 3]) -> f64 {
+    let [a, b, c] = box_vectors;
+
+    let cross = [
+        b[1] * c[2] - b[2] * c[1],
+        b[2] * c[0] - b[0] * c[2],
+        b[0] * c[1] - b[1] * c[0],
+    ];
+
+    let dot = a[0] * cross[0] + a[1] * cross[1] + a[2] * cross[2];
+    dot.abs()
 }
 
 impl fmt::Display for Structure {

--- a/crates/bio-forge/src/ops/solvate.rs
+++ b/crates/bio-forge/src/ops/solvate.rs
@@ -508,8 +508,6 @@ fn replace_with_ions(
 
     water_indices.shuffle(rng);
 
-    // const SALT_CONCENTRATION_M: f64 = 0.15;
-
     // Add neutral ions to achieve desired salt concentration
     match config.salt_concentration {
         Some(salt_concentration) => {

--- a/crates/bio-forge/src/ops/solvate.rs
+++ b/crates/bio-forge/src/ops/solvate.rs
@@ -538,13 +538,20 @@ fn replace_with_ions(
     // Add ions to reach target charge
     while (charge_diff - total_ion_charge(&ion_plan)) != 0 {
         let ion = if (charge_diff - total_ion_charge(&ion_plan)) < 0 {
-            Ion::Anion(*config.anions.choose(rng).expect("Required "))
+            Ion::Anion(
+                *config
+                    .choose_random_anion(rng)
+                    .ok_or(Error::IonizationFailed {
+                        details: "No anions configured".to_string(),
+                    })?,
+            )
         } else {
             Ion::Cation(
                 *config
-                    .cations
-                    .choose(rng)
-                    .expect("checked non-empty cation list"),
+                    .choose_random_cation(rng)
+                    .ok_or(Error::IonizationFailed {
+                        details: "No cations configured".to_string(),
+                    })?,
             )
         };
 


### PR DESCRIPTION
Updated solvate to allow a configurable salt concentration. Changes are as follows:
- Updated `SolvateConfig` to add an optional `salt_concentration` parameter
- Updated `replace_with_ions` to first add ions to achieve desired salt concentration
- Updated `SolvateArgs` to add new `--salt-concentation` argument

Notes:
- This is a simple implementation for achieving neutrality and relies on the fact that only monovalent anions are currently supported. The logic will need updating if this is not the case
- Method for determining total ions to add to the structure assumes that the water molarity is correct (55.5 M) then calculates the total number of ions to add as a ratio of the desired salt concentration to this water molarity. An alternative is to calculate the total number of ions from the box volume (I added methods for calculating box volume from the box vectors but went with the simpler total ion concentration)
- The method of adding ions replaces waters so the total number of waters changes as we add more ions which affects the correct total ions to add. A correction needs to be applied to account for this but requires the fact that we know the formula for the neutral ion (e.g. NaCl, MgCl2). As you support choosing from a list of available ions rather than a single ion, knowing this formula in advance makes things more tricky so I have left this as a todo.

I have added documentation for the new attributes. I have not yet added documentation for the added helper functions and I have not added tests. Let me know what else needs adding for this PR (more documentation, tests, integration with the webui etc).

Great work on this amazing crate. As scientists we often make do with substandard tooling, it's great to try and push this space forward.